### PR TITLE
Remove PostgreSQL 9.2 and 9.3 (EoL)

### DIFF
--- a/manage_images
+++ b/manage_images
@@ -8,7 +8,7 @@ SCRIPT=$(basename ${0})
 
 # Supported distributions and PostgreSQL versions
 SUPPORTEDDISTROS="centos6 ubuntu14.04"
-SUPPORTEDPGVERS="9.2 9.3 9.4 9.5 9.6 10"
+SUPPORTEDPGVERS="9.4 9.5 9.6 10"
 
 # Use remote images by default
 LOCAL="--pull"


### PR DESCRIPTION
According to https://www.postgresql.org/support/versioning/

Next step is adding PostgreSQL 11.