### PR TITLE
Remove unneeded workaround, not working after the release of cython 3.0.0

### DIFF
--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -34,11 +34,8 @@ RUN apt-get -qq -o=Dpkg::Use-Pty=0 update > /dev/null && \
      sudo > /dev/null && \
     PATH=${PATH}:/usr/lib/postgresql/${POSTGRESQL_VER}/bin/ && \
     pip3 -q install setuptools_git && \
-    pip3 -q install Cython && \
+    pip3 -q install pymssql  && \
     pip3 -q install psycopg2 && \
-    # Done following https://stackoverflow.com/a/52749308/4055246
-    # We should replace pymssql: https://github.com/pymssql/pymssql/issues/668
-    pip3 -q install --no-binary :all: pymssql==2.1.5 && \
     apt-get -qq -o=Dpkg::Use-Pty=0 -y purge python3-pip python3-dev > /dev/null && \
     apt-get -qq -o=Dpkg::Use-Pty=0 -y --purge autoremove > /dev/null && \
     apt-get -qq -o=Dpkg::Use-Pty=0 clean > /dev/null


### PR DESCRIPTION
Updating the Ubuntu 20.04 images started to fail because of https://github.com/pymssql/pymssql/issues/826

However, we can remove this old workaround, as now we can again get the binaries from pipy, and we don't need to build pymyssql anymore.