### PR TITLE
Install pymssql and psycopg2 directly from Ubuntu 20.04

### DIFF
--- a/ubuntu20.04/Dockerfile
+++ b/ubuntu20.04/Dockerfile
@@ -30,15 +30,9 @@ RUN apt-get -qq -o=Dpkg::Use-Pty=0 update > /dev/null && \
      libsybdb5 \
      make \
      python3 \
-     python3-dev \
-     python3-pip \
+     python3-pymssql \
+     python3-psycopg2 \
      sudo > /dev/null && \
-    PATH=${PATH}:/usr/lib/postgresql/${POSTGRESQL_VER}/bin/ && \
-    pip3 -q install setuptools_git && \
-    pip3 -q install pymssql  && \
-    pip3 -q install psycopg2 && \
-    apt-get -qq -o=Dpkg::Use-Pty=0 -y purge python3-pip python3-dev > /dev/null && \
-    apt-get -qq -o=Dpkg::Use-Pty=0 -y --purge autoremove > /dev/null && \
     apt-get -qq -o=Dpkg::Use-Pty=0 clean > /dev/null
 
 # Configure sudo


### PR DESCRIPTION
Seems something broke pymssql from pip on Ubuntu 20.04.

- Ubuntu 20.04 is going EoL in a few days
- For all other OS we avoid using pip, even for Ubuntu 24.04
- pymssql and psycopg2 are available at Ubuntu 20.04 even if they are older version.

So let's us them. It will also improve image building times, as otherwise at least psmssql was being built when using pip.